### PR TITLE
Enhance Fan Speed Control: New Fan Service with Rate Limiting for Daikin

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "axios": "^1.6.7",
+    "axios-rate-limit": "^1.4.0",
     "tslog": "^4.9.2"
   },
   "devDependencies": {

--- a/src/accessories/climate.ts
+++ b/src/accessories/climate.ts
@@ -193,7 +193,7 @@ export default class ClimateAccessory {
   }
 
   async getFanStatus():Promise<CharacteristicValue> {
-    this.platform.log.info(`Accessory: getFanStatus() for device '${this.accessory.displayName}'`);
+    this.platform.log.debug(`Accessory: getFanStatus() for device '${this.accessory.displayName}'`);
 
     const value = this.accessory.context.device.getFanSpeedNumber();
     this.services['Fan'].updateCharacteristic(this.platform.Characteristic.On, value !== 0);
@@ -201,7 +201,7 @@ export default class ClimateAccessory {
   }
 
   async setFanStatus(value: CharacteristicValue) {
-    this.platform.log.info(`Accessory: setFanStatus() for device '${this.accessory.displayName}'`);
+    this.platform.log.debug(`Accessory: setFanStatus() for device '${this.accessory.displayName}'`);
 
     let speed = this._lastFanSpeed;
     if (value === false) {

--- a/src/accessories/climate.ts
+++ b/src/accessories/climate.ts
@@ -118,8 +118,7 @@ export default class ClimateAccessory {
     .onGet(this.getFanStatus.bind(this))
     .onSet(this.setFanStatus.bind(this));
 
-    this.services['Fan']
-    .getCharacteristic(this.platform.Characteristic.RotationSpeed)
+    this.services['Fan'].getCharacteristic(this.platform.Characteristic.RotationSpeed)
     .setProps({
       unit: null,
       format: this.platform.Characteristic.Formats.UINT8,
@@ -178,9 +177,7 @@ export default class ClimateAccessory {
 
   async setClimateActive(value: CharacteristicValue) {
     this.platform.log.debug(`Accessory: setClimateActive() for device '${this.accessory.displayName}'`);
-
-    const active = value === this.platform.Characteristic.Active.ACTIVE;
-    this.accessory.context.device.setPowerStatus(active);
+    this.accessory.context.device.setPowerStatus(value === this.platform.Characteristic.Active.ACTIVE ? true : false);
   }
 
   async getClimateActive():Promise<CharacteristicValue> { 
@@ -195,15 +192,15 @@ export default class ClimateAccessory {
   async getFanStatus():Promise<CharacteristicValue> {
     this.platform.log.debug(`Accessory: getFanStatus() for device '${this.accessory.displayName}'`);
 
-    const value = this.accessory.context.device.getFanSpeedNumber();
-    this.services['Fan'].updateCharacteristic(this.platform.Characteristic.On, value !== 0);
+    const value = this.accessory.context.device.getFanSpeedNumber() !== 0;
+    this.services['Fan'].updateCharacteristic(this.platform.Characteristic.On, value);
     return value;
   }
 
   async setFanStatus(value: CharacteristicValue) {
     this.platform.log.debug(`Accessory: setFanStatus() for device '${this.accessory.displayName}'`);
 
-    let speed = this._lastFanSpeed;
+    let speed = this._lastFanSpeed; // restore to previous non-zero speed
     if (value === false) {
       // turn off fan means turn on auto-speed mode
       speed = 0;

--- a/src/accessories/climate.ts
+++ b/src/accessories/climate.ts
@@ -27,6 +27,7 @@ import {DaikinLocalAPI, DaikinDevice} from '../daikin-local';
 export default class ClimateAccessory {
   private services: Service[] = [];
   private _refreshInterval: NodeJS.Timer | undefined;
+  private _lastFanSpeed = 1; // slient
 
   constructor(
     private readonly platform: DaikinPlatform,
@@ -109,12 +110,22 @@ export default class ClimateAccessory {
     .onSet(this.setHeatingThresholdTemperature.bind(this))
     .onGet(this.getHeatingThresholdTemperature.bind(this));
 
-    this.services['Climate']
+    // Fan control service
+    this.services['Fan'] = this.accessory.getService(this.platform.Service.Fan)
+      || this.accessory.addService(this.platform.Service.Fan);
+
+    this.services['Fan'].getCharacteristic(this.platform.Characteristic.On)
+    .onGet(this.getFanStatus.bind(this))
+    .onSet(this.setFanStatus.bind(this));
+
+    this.services['Fan']
     .getCharacteristic(this.platform.Characteristic.RotationSpeed)
     .setProps({
-      minValue: 0,
+      unit: null,
+      format: this.platform.Characteristic.Formats.UINT8,
+      minValue: 1,
       maxValue: 6,
-      minStep: 1,
+      validValues: [1, 2, 3, 4, 5, 6] 
     })
     .onGet(this.getRotationSpeed.bind(this))
     .onSet(this.setRotationSpeed.bind(this));
@@ -167,24 +178,49 @@ export default class ClimateAccessory {
 
   async setClimateActive(value: CharacteristicValue) {
     this.platform.log.debug(`Accessory: setClimateActive() for device '${this.accessory.displayName}'`);
-    this.accessory.context.device.setPowerStatus(value === this.platform.Characteristic.Active.ACTIVE ? true : false);
-    this.services['Climate'].updateCharacteristic(this.platform.Characteristic.Active, value);  
+
+    const active = value === this.platform.Characteristic.Active.ACTIVE;
+    this.accessory.context.device.setPowerStatus(active);
   }
 
   async getClimateActive():Promise<CharacteristicValue> { 
-    
     this.platform.log.debug(`Accessory: getClimateActive() for device '${this.accessory.displayName}'`);
 
-    const active = this.accessory.context.device.getPowerStatus() ? this.platform.Characteristic.Active.ACTIVE
-    : this.platform.Characteristic.Active.INACTIVE;
+    const active = this.accessory.context.device.getPowerStatus() ?
+      this.platform.Characteristic.Active.ACTIVE : this.platform.Characteristic.Active.INACTIVE;
+    this.services['Climate'].updateCharacteristic(this.platform.Characteristic.Active, active);
     return active;
+  }
+
+  async getFanStatus():Promise<CharacteristicValue> {
+    this.platform.log.info(`Accessory: getFanStatus() for device '${this.accessory.displayName}'`);
+
+    const value = this.accessory.context.device.getFanSpeedNumber();
+    this.services['Fan'].updateCharacteristic(this.platform.Characteristic.On, value !== 0);
+    return value;
+  }
+
+  async setFanStatus(value: CharacteristicValue) {
+    this.platform.log.info(`Accessory: setFanStatus() for device '${this.accessory.displayName}'`);
+
+    let speed = this._lastFanSpeed;
+    if (value === false) {
+      // turn off fan means turn on auto-speed mode
+      speed = 0;
+    }
+    this.setRotationSpeed(speed);
   }
 
   async getRotationSpeed():Promise<CharacteristicValue> {
       
-      this.platform.log.debug(`Accessory: getRotationSpeed() for device '${this.accessory.displayName}'`);
-   
-      return this.accessory.context.device.getFanSpeedNumber();
+    this.platform.log.debug(`Accessory: getRotationSpeed() for device '${this.accessory.displayName}'`);
+
+    let value = this.accessory.context.device.getFanSpeedNumber();
+    if (value === 0) {
+      value = this._lastFanSpeed;
+    }
+    this.services['Fan'].updateCharacteristic(this.platform.Characteristic.RotationSpeed, value);
+    return value;
   }
 
   async setRotationSpeed(value: CharacteristicValue) {
@@ -195,6 +231,10 @@ export default class ClimateAccessory {
 
     switch (value) {
       case 0:
+        const lastFanSpeed = this.accessory.context.device.getFanSpeedNumber();
+        if (lastFanSpeed !== 0) {
+          this._lastFanSpeed = lastFanSpeed;
+        }
         speed = CLIMATE_FAN_SPEED_AUTO;
         break;
 
@@ -368,14 +408,18 @@ export default class ClimateAccessory {
       
       this.platform.log.debug(`Accessory: getCoolingThresholdTemperature() for device '${this.accessory.displayName}'`);
   
-      return this.accessory.context.device.getTargetTemperatureWithMode(CLIMATE_MODE_COOLING);
+      const value = this.accessory.context.device.getTargetTemperatureWithMode(CLIMATE_MODE_COOLING);
+      this.services['Climate'].updateCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature, value);
+      return value;
   }
 
   async getHeatingThresholdTemperature():Promise<CharacteristicValue> {
       
       this.platform.log.debug(`Accessory: getHeatingThresholdTemperature() for device '${this.accessory.displayName}'`);
   
-      return this.accessory.context.device.getTargetTemperatureWithMode(CLIMATE_MODE_HEATING);
+      const value = this.accessory.context.device.getTargetTemperatureWithMode(CLIMATE_MODE_HEATING);
+      this.services['Climate'].updateCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature, value);
+      return value;
   }
 
   async setCoolingThresholdTemperature(value: CharacteristicValue) {
@@ -386,9 +430,6 @@ export default class ClimateAccessory {
 
     this.accessory.context.device.setOperationMode(CLIMATE_MODE_COOLING);
     this.accessory.context.device.setTargetTemperature(threshold);
-
-    this.services['Climate'].getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
-      .updateValue(value);
   }
 
   async setHeatingThresholdTemperature(value: CharacteristicValue) {
@@ -399,9 +440,6 @@ export default class ClimateAccessory {
 
     this.accessory.context.device.setOperationMode(CLIMATE_MODE_HEATING);
     this.accessory.context.device.setTargetTemperature(threshold);
-
-    this.services['Climate'].getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
-      .updateValue(value);
   }
 
   async setTargetHeaterCoolerState(value: CharacteristicValue) {
@@ -430,9 +468,6 @@ export default class ClimateAccessory {
 
 
     this.accessory.context.device.setOperationMode(mode);
-
-    this.services['Climate'].getCharacteristic(this.platform.Characteristic.TargetHeaterCoolerState)
-      .updateValue(value);
   }
 
   async getMotionDetection():Promise<CharacteristicValue> {

--- a/src/daikin-local.ts
+++ b/src/daikin-local.ts
@@ -1,5 +1,6 @@
 import DaikinPlatformLogger from './logger';
 import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
 
 import {
   USER_AGENT,
@@ -29,6 +30,8 @@ const CLIMATE_OPERATE_SETTING = '02';
 const COMMAND_QUERY = '{"requests":[{"op":2,"to":"/dsiot/edge.adp_i?filter=pv"},{"op":2,"to":"/dsiot/edge.adp_d?filter=pv"},{"op":2,"to":"/dsiot/edge.adp_f?filter=pv"},{"op":2,"to":"/dsiot/edge.dev_i?filter=pv"},{"op":2,"to":"/dsiot/edge/adr_0100.dgc_status?filter=pv"}]}';
 const COMMAND_QUERY_WITH_MD = '{"requests":[{"op":2,"to":"/dsiot/edge.adp_i?filter=pv"},{"op":2,"to":"/dsiot/edge.adp_d?filter=pv"},{"op":2,"to":"/dsiot/edge.adp_f?filter=pv"},{"op":2,"to":"/dsiot/edge.dev_i?filter=pv"},{"op":2,"to":"/dsiot/edge/adr_0100.dgc_status"},{"op":2,"to":"/dsiot/edge/adr_0200.dgc_status"}]}';
 
+const http = rateLimit(axios.create(), { maxRequests: 1, perMilliseconds: 500 });
+
 export class DaikinDevice {
 
   protected _IP: string;
@@ -57,7 +60,7 @@ export class DaikinDevice {
       return this._Response;
     }
   
-    const response = await axios.request({
+    const response = await http.request({
       method: 'post',
       url: `http://${this._IP}${ENDPOINT}`,
       headers: {
@@ -102,7 +105,7 @@ export class DaikinDevice {
     this.log.debug(`Daikin - setShowSSID(${bShow}): Name: ${this.getDeviceName()}`);
     const command = {"requests":[{"op":3,"to":"/dsiot/edge.adp_d","pc":{"pn":"adp_d","pch":[{"pn":"disp_ssid","pv": bShow ? 0 :1 }]}}]};
 
-    const response = await axios.request({
+    const response = await http.request({
       method: 'post',
       url: `http://${this._IP}${ENDPOINT}`,
       headers: {
@@ -576,7 +579,7 @@ export class DaikinDevice {
 
     const param = {"requests": [{"op": 3,"to": "/dsiot/edge/adr_0100.dgc_status","pc": {"pn": "dgc_status","pch": [{"pn": "e_1002","pch": command}]}}]};
     
-    const response = await axios.request({
+    const response = await http.request({
       method: 'post',
       url: `http://${this._IP}${ENDPOINT}`,
       headers: {


### PR DESCRIPTION
- **Issue with HeaterCooler:**  
  - Exporting the RotationSpeed characteristic in the HeaterCooler service doesn't work properly with HomeKit.

- **Standalone Fan Service:**  
  - Added a separate Fan service with dedicated methods:
    - `setFanStatus` / `getFanStatus`
    - `setRotationSpeed` / `getRotationSpeed`
  - **Behavior:**
    - Turning on the separate fan control signifies manual fan speed control.
    - Turning off the fan control reverts the air conditioner back to auto-speed mode.

- **Rate Limiting Integration:**  
  - Integrated **axios-rate-limit** to mitigate 429 errors when adjusting or sliding the fan speed controller.
  - Ensures requests are throttled to prevent overwhelming the device and crashing Homebridge.

- **Testing:**  
  - Changes have been tested successfully in my environment with HomeKit.